### PR TITLE
Fix/write output channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Docstring return value of read_output_channel and read_channel
+- Write channel wrongly updating other channels
 
 ## v0.11.1 - 04.12.25
 

--- a/src/cpx_io/cpx_system/cpx_ap/ap_module.py
+++ b/src/cpx_io/cpx_system/cpx_ap/ap_module.py
@@ -524,7 +524,7 @@ class ApModule(CpxModule):
                 self.system_entry_registers.outputs + output_index, size
             )
             for i in range(size):
-                prev_data[i + output_index] = old_data[i]
+                prev_data[i + output_index * 2] = old_data[i]
             ApModule._convert_channel_data_to_bytes(
                 self.channels.outputs[channel], value, prev_data
             )

--- a/tests/unit_tests/cpx_system/cpx_ap/test-apdd.json
+++ b/tests/unit_tests/cpx_system/cpx_ap/test-apdd.json
@@ -1,0 +1,57 @@
+{
+    "ChannelGroups": [
+        {
+            "ChannelGroupId": 0,
+            "Channels": [
+                {
+                    "ChannelId": 0,
+                    "Count": 32,
+                    "Offset": 0
+                }
+            ],
+            "Name": "32 Coils"
+        }
+    ],
+    "Channels": [
+        {
+            "Bits": 1,
+            "ChannelId": 0,
+            "DataType": "BOOL",
+            "Description": "Coils",
+            "Direction": "out",
+            "Name": "Coil %d"
+        }
+    ],
+    "Variants": {
+        "DefaultModuleCode": 1337,
+        "DeviceIdentification": {
+            "ProductCategory": 1,
+            "ProductFamily": "VTUX",
+            "ProductKey": {
+                "ParameterId": 0,
+                "ParameterInstance": 0
+            },
+            "VendorId": 1
+        },
+        "VariantList": [
+            {
+                "ChannelGroupIds": [
+                    0
+                ],
+                "Description": "Description",
+                "Name": "Name",
+                "ParameterGroupIds": [
+                    0
+                ],
+                "VariantIdentification": {
+                    "AlternativeFestoPartNumbersDeviceList": [
+                        12345
+                    ],
+                    "ModuleCode": 1337,
+                    "NumberOfApNodes": 1,
+                    "OrderText": "TestModule"
+                }
+            }
+        ]
+    }
+}

--- a/tests/unit_tests/cpx_system/cpx_ap/test_ap_module_channel.py
+++ b/tests/unit_tests/cpx_system/cpx_ap/test_ap_module_channel.py
@@ -349,3 +349,43 @@ class TestApModule:
         module.base.write_reg_data.assert_called_with(
             bytearray(b"\xff\xf0\xc0\xa5\x92\x36\x47\xc8"), None
         )
+
+    def test_write_output_channel(self, module_fixture):
+        module = module_fixture
+        module.apdd_information.product_category = ProductCategory.VTUX.value
+        module.information = CpxAp.ApInformation(input_size=0, output_size=4)
+        channel_outputs = [
+            Channel(
+                array_size=None,
+                bits=1,
+                bit_offset=bit_offset,
+                byte_swap_needed=None,
+                channel_id=0,
+                data_type="BOOL",
+                description="",
+                direction="out",
+                name="Coil %d",
+                parameter_group_ids=[2],
+                profile_list=[7],
+            )
+            for bit_offset in range(32)
+        ]
+        module.channels.outputs = channel_outputs
+        if module.channels.outputs and len(module.channels.outputs) > 0:
+            biggest_byte_offset_channel = max(
+                module.channels.outputs, key=lambda x: x.bit_offset
+            )
+            module.output_byte_size = div_ceil(
+                biggest_byte_offset_channel.bit_offset
+                + biggest_byte_offset_channel.bits,
+                8,
+            )
+
+        module.system_entry_registers.outputs = 5000
+        module.base = Mock()
+        # return channel 18 already set
+        module.base.read_reg_data = Mock(return_value=b"\x04\x00")
+        # Act
+        module.write_channel(16, 1)
+        # channel 16 and 18 should be now set
+        module.base.write_reg_data.assert_called_with(bytearray(b"\x05\x00"), 5001)

--- a/tests/unit_tests/cpx_system/cpx_ap/test_build_channel_list.py
+++ b/tests/unit_tests/cpx_system/cpx_ap/test_build_channel_list.py
@@ -1,5 +1,8 @@
 """Contains tests for Channel build"""
 
+import json
+from pathlib import Path
+
 from cpx_io.cpx_system.cpx_ap.builder.channel_builder import (
     ChannelGroup,
     Channel,
@@ -7,7 +10,10 @@ from cpx_io.cpx_system.cpx_ap.builder.channel_builder import (
     build_channel,
     build_channel_list,
 )
-from cpx_io.cpx_system.cpx_ap.builder.apdd_information_builder import Variant
+from cpx_io.cpx_system.cpx_ap.builder.apdd_information_builder import (
+    Variant,
+    build_variant_list,
+)
 
 
 class TestBuildChannelGroup:
@@ -84,6 +90,12 @@ class TestBuildChannel:
 
 class TestBuildChannelList:
     "Test build_channel_list"
+
+    @staticmethod
+    def get_test_apdd_dict():
+        fixture_path = Path(__file__).with_name("test-apdd.json")
+        with fixture_path.open(encoding="utf-8") as fixture_file:
+            return json.load(fixture_file)
 
     def get_test_channel_group_list(self, n_channel_groups, n_channels_per_group):
         channel_group_dict_list = []
@@ -228,3 +240,19 @@ class TestBuildChannelList:
             assert channel.channel_id == 0
         for channel in output_channel_list[3:6]:
             assert channel.channel_id == 1
+
+    def test_build_channel_list_from_test_apdd_returns_32_output_channels(self):
+        # Arrange
+        apdd = self.get_test_apdd_dict()
+        variant = build_variant_list(apdd)[0]
+
+        # Act
+        channel_list = build_channel_list(apdd=apdd, variant=variant, direction="out")
+
+        # Assert
+        assert len(channel_list) == 32
+        for i, channel in enumerate(channel_list):
+            assert isinstance(channel, Channel)
+            assert channel.channel_id == 0
+            assert channel.direction == "out"
+            assert channel.bit_offset == i


### PR DESCRIPTION
If process data of a particular module was >= 2 byte write_channel read the previous set output data to wrong position, losing the information in the update.